### PR TITLE
Set exported to true for service that uses intent filter

### DIFF
--- a/lib/android/app/src/main/AndroidManifest.xml
+++ b/lib/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         <service android:name=".core.ProxyService"/>
 
         <service
-            android:name=".fcm.FcmInstanceIdListenerService">
+            android:name=".fcm.FcmInstanceIdListenerService"
+            android:exported="true">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
                 <action android:name="com.google.firebase.INSTANCE_ID_EVENT" />


### PR DESCRIPTION
Android 12 requires that the `exported` attribute is added to activities, services and broadcast receivers that uses intent filters.

As our app is targeting API level 31, Play store refuses to accept the aab and apk files until this is fixed.